### PR TITLE
ref(selector): rename from ngrxSelector to ngrxSelect

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ export class TacoComponent {
 }
 ```
 
-## ngrxSelector
+## ngrxSelect
 
 With NgRx Smartish you can reference NgRx Selectors directly in your Angular Component's template without the need to inject the `store`. You simple need to add the `MemoizedSelector` in your component class and reference that property with the `ngrxSelector` pipe in your template.
 
@@ -49,7 +49,7 @@ import { selectError } from 'YOUR-STORE'
 
 @Component({
     selector: 'app-error',
-    template: `<p>{{ error$ | ngrxSelector | async }}</p>`
+    template: `<p>{{ error$ | ngrxSelect | async }}</p>`
 })
 export class ErrorComponent {
     error$ = selectError;

--- a/projects/ngrx-smartish/src/lib/ngrx-select/selector.pipe.ts
+++ b/projects/ngrx-smartish/src/lib/ngrx-select/selector.pipe.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 import { SELECT_STORE_TOKEN } from './token';
 
 @Pipe({
-  name: 'ngrxSelector',
+  name: 'ngrxSelect',
 })
 export class NgRxSelectorPipe<TResult, TState = object>
   implements PipeTransform {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,5 +3,5 @@
 <button type="button" [ngrxDispatch]="actionWithProp" [ngrxProp]="taco">Trigger Smartish Dispatch With Prop</button>
 
 <pre>
-    {{ taco$ | ngrxSelector | async | json }}
+    {{ taco$ | ngrxSelect | async | json }}
 </pre>


### PR DESCRIPTION
- Change `NgRxSelectorPipe` name from `ngrxSelector` to `ngrxSelect` for improved readability